### PR TITLE
Adding more item IDs

### DIFF
--- a/lists/official.json
+++ b/lists/official.json
@@ -1062,8 +1062,8 @@
 			"displayItemId": 8850,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 8850 ],
-				"count": 1
+				"itemIds": [ 8844, 8845, 8846, 8847, 8848, 8849, 8850 ],
+				"count": 7
 			}
 		},
 		{
@@ -3453,8 +3453,8 @@
 			"displayItemId": 12954,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 12954 ],
-				"count": 1
+				"itemIds": [ 8844, 8845, 8846, 8847, 8848, 8849, 8850, 12954 ],
+				"count": 8
 			}
 		},
 		{
@@ -12728,7 +12728,15 @@
 			"tip": "May the bird gods bless you with evil chicken pieces",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log#Miscellaneous",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragon_full_helm_detail.png/277px-Dragon_full_helm_detail.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 1
+			}
 		},
 		{
 			"id": "b8f55499-8c32-4b15-9a70-c80cefb297c1",
@@ -12736,7 +12744,15 @@
 			"tip": "May the bird gods bless you with evil chicken pieces",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log#Miscellaneous",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragon_full_helm_detail.png/277px-Dragon_full_helm_detail.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 2
+			}
 		},
 		{
 			"id": "a1b4d9cc-8e86-45fe-af4b-61d844a5b078",
@@ -12744,7 +12760,15 @@
 			"tip": "May the bird gods bless you with evil chicken pieces",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log#Miscellaneous",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragon_full_helm_detail.png/277px-Dragon_full_helm_detail.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 3
+			}
 		},
 		{
 			"id": "89d777ac-5d60-4720-ba28-e23594ee06c1",
@@ -12752,7 +12776,15 @@
 			"tip": "May the bird gods bless you with evil chicken pieces",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log#Miscellaneous",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragon_full_helm_detail.png/277px-Dragon_full_helm_detail.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 4
+			}
 		},
 		{
 			"id": "1a25f42e-1202-40f3-b001-d2de28f6b530",
@@ -12760,7 +12792,15 @@
 			"tip": "May the bird gods bless you with evil chicken pieces",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log#Miscellaneous",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragon_full_helm_detail.png/277px-Dragon_full_helm_detail.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 5
+			}
 		},
 		{
 			"id": "bd9208a5-8c14-4fc9-b13f-b5323d036391",
@@ -12794,7 +12834,12 @@
 			"tip": "Boss or Minigame?",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Zalcano",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Zalcano_shard_detail.png/221px-Zalcano_shard_detail.png",
-			"displayItemId": 23908
+			"displayItemId": 23908,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [ 23953, 23908 ],
+				"count": 1
+			}
 		},
 		{
 			"id": "08a9dd78-a0d5-4497-9277-4b66097dba4b",
@@ -12802,7 +12847,12 @@
 			"tip": "Money Dragon",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Vorkath",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragonbone_necklace_detail.png/147px-Dragonbone_necklace_detail.png",
-			"displayItemId": 22111
+			"displayItemId": 22111,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [ 22111, 11286, 22006 ],
+				"count": 1
+			}
 		},
 		{
 			"id": "b759ce53-4312-4a54-8b5d-48a7ec52bd34",
@@ -12810,7 +12860,14 @@
 			"tip": "Ironman retirement home",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/234px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 1
+			}
 		},
 		{
 			"id": "37a77af7-505f-440b-bb3f-5fe03bd1c1a9",
@@ -12818,7 +12875,14 @@
 			"tip": "Ironman retirement home",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/234px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 2
+			}
 		},
 		{
 			"id": "d7f94c27-684f-4f4b-8069-fa8263999a44",
@@ -12826,7 +12890,14 @@
 			"tip": "Ironman retirement home",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/234px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 3
+			}
 		},
 		{
 			"id": "8fa63977-c114-4733-ac89-5b4299e086a2",
@@ -12834,7 +12905,14 @@
 			"tip": "Ironman retirement home",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/234px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 4
+			}
 		},
 		{
 			"id": "384deb72-3c32-4646-ac51-30c661ebcab2",
@@ -12842,7 +12920,14 @@
 			"tip": "Ironman retirement home",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/234px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 5
+			}
 		},
 		{
 			"id": "ae31a0d7-1dfa-496a-bcd1-aa0703172b65",

--- a/lists/tedious.json
+++ b/lists/tedious.json
@@ -1062,8 +1062,8 @@
 			"displayItemId": 8850,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 8850 ],
-				"count": 1
+				"itemIds": [ 8844, 8845, 8846, 8847, 8848, 8849, 8850 ],
+				"count": 7
 			}
 		},
 		{
@@ -3453,8 +3453,8 @@
 			"displayItemId": 12954,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 12954 ],
-				"count": 1
+				"itemIds": [ 8844, 8845, 8846, 8847, 8848, 8849, 8850, 12954 ],
+				"count": 8
 			}
 		},
 		{
@@ -12526,7 +12526,15 @@
 			"tip": "1 Miscellaneous log slot",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log",
 			"imageLink": "https://oldschool.runescape.wiki/images/2/2e/Collection_log.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 1
+			}
 		},
 		{
 			"id": "7a109368-c716-4b5e-8683-888a01298b16",
@@ -12534,7 +12542,15 @@
 			"tip": "1 Miscellaneous log slot",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log",
 			"imageLink": "https://oldschool.runescape.wiki/images/2/2e/Collection_log.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 2
+			}
 		},
 		{
 			"id": "68d04c37-b686-429e-b72b-6efb54738b10",
@@ -12542,7 +12558,15 @@
 			"tip": "1 Miscellaneous log slot",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log",
 			"imageLink": "https://oldschool.runescape.wiki/images/2/2e/Collection_log.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 3
+			}
 		},
 		{
 			"id": "1ccafb95-d36e-436c-ab65-c73aad344557",
@@ -12550,7 +12574,15 @@
 			"tip": "1 Miscellaneous log slot",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log",
 			"imageLink": "https://oldschool.runescape.wiki/images/2/2e/Collection_log.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 4
+			}
 		},
 		{
 			"id": "52b75bae-5757-4fde-89c1-0d54fad11790",
@@ -12558,7 +12590,15 @@
 			"tip": "1 Miscellaneous log slot",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log",
 			"imageLink": "https://oldschool.runescape.wiki/images/2/2e/Collection_log.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 5
+			}
 		},
 		{
 			"id": "fd0e4fce-e558-426e-81f2-82895462332b",
@@ -12592,7 +12632,12 @@
 			"tip": "1 Zalcano unique",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Zalcano",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Zalcano_shard_detail.png/200px-Zalcano_shard_detail.png",
-			"displayItemId": 23908
+			"displayItemId": 23908,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [ 23953, 23908 ],
+				"count": 1
+			}
 		},
 		{
 			"id": "dfcb3155-0e12-444e-bab7-c8e3c5aa52cf",
@@ -12600,7 +12645,12 @@
 			"tip": "1 Vorkath unique",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Vorkath",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragonbone_necklace_detail.png/200px-Dragonbone_necklace_detail.png",
-			"displayItemId": 22111
+			"displayItemId": 22111,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [ 22111, 11286, 22006 ],
+				"count": 1
+			}
 		},
 		{
 			"id": "e2036f41-dbce-4f48-9834-210371ae0c5c",
@@ -12608,7 +12658,14 @@
 			"tip": "1 Nightmare unique",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/200px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 1
+			}
 		},
 		{
 			"id": "3cafb876-c10f-4396-8e3e-12e9fecf2adb",
@@ -12616,7 +12673,14 @@
 			"tip": "1 Nightmare unique",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/200px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 2
+			}
 		},
 		{
 			"id": "3df7f914-6bce-4f3c-a6c3-581e9c4eebce",
@@ -12624,7 +12688,14 @@
 			"tip": "1 Nightmare unique",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/200px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 3
+			}
 		},
 		{
 			"id": "7af50f50-1d4a-4567-b205-2f35c30eb1b5",
@@ -12632,7 +12703,14 @@
 			"tip": "1 Nightmare unique",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/200px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 4
+			}
 		},
 		{
 			"id": "ac401402-3e8d-4785-86de-1708ce73da65",
@@ -12640,7 +12718,14 @@
 			"tip": "1 Nightmare unique",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/200px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 5
+			}
 		},
 		{
 			"id": "3288456d-a278-414f-9280-3e0dea65cdda",

--- a/tiers/easy.json
+++ b/tiers/easy.json
@@ -1063,8 +1063,8 @@
 			"displayItemId": 8850,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 8850 ],
-				"count": 1
+				"itemIds": [ 8844, 8845, 8846, 8847, 8848, 8849, 8850 ],
+				"count": 7
 			}
 		},
 		{

--- a/tiers/master-tedious.json
+++ b/tiers/master-tedious.json
@@ -1213,7 +1213,15 @@
 			"tip": "1 Miscellaneous log slot",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log",
 			"imageLink": "https://oldschool.runescape.wiki/images/2/2e/Collection_log.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 1
+			}
 		},
 		{
 			"id": "7a109368-c716-4b5e-8683-888a01298b16",
@@ -1221,7 +1229,15 @@
 			"tip": "1 Miscellaneous log slot",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log",
 			"imageLink": "https://oldschool.runescape.wiki/images/2/2e/Collection_log.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 2
+			}
 		},
 		{
 			"id": "68d04c37-b686-429e-b72b-6efb54738b10",
@@ -1229,7 +1245,15 @@
 			"tip": "1 Miscellaneous log slot",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log",
 			"imageLink": "https://oldschool.runescape.wiki/images/2/2e/Collection_log.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 3
+			}
 		},
 		{
 			"id": "1ccafb95-d36e-436c-ab65-c73aad344557",
@@ -1237,7 +1261,15 @@
 			"tip": "1 Miscellaneous log slot",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log",
 			"imageLink": "https://oldschool.runescape.wiki/images/2/2e/Collection_log.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 4
+			}
 		},
 		{
 			"id": "52b75bae-5757-4fde-89c1-0d54fad11790",
@@ -1245,7 +1277,15 @@
 			"tip": "1 Miscellaneous log slot",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log",
 			"imageLink": "https://oldschool.runescape.wiki/images/2/2e/Collection_log.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 5
+			}
 		},
 		{
 			"id": "fd0e4fce-e558-426e-81f2-82895462332b",
@@ -1279,7 +1319,12 @@
 			"tip": "1 Zalcano unique",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Zalcano",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Zalcano_shard_detail.png/200px-Zalcano_shard_detail.png",
-			"displayItemId": 23908
+			"displayItemId": 23908,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [ 23953, 23908 ],
+				"count": 1
+			}
 		},
 		{
 			"id": "dfcb3155-0e12-444e-bab7-c8e3c5aa52cf",
@@ -1287,7 +1332,12 @@
 			"tip": "1 Vorkath unique",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Vorkath",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragonbone_necklace_detail.png/200px-Dragonbone_necklace_detail.png",
-			"displayItemId": 22111
+			"displayItemId": 22111,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [ 22111, 11286, 22006 ],
+				"count": 1
+			}
 		},
 		{
 			"id": "e2036f41-dbce-4f48-9834-210371ae0c5c",
@@ -1295,7 +1345,14 @@
 			"tip": "1 Nightmare unique",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/200px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 1
+			}
 		},
 		{
 			"id": "3cafb876-c10f-4396-8e3e-12e9fecf2adb",
@@ -1303,7 +1360,14 @@
 			"tip": "1 Nightmare unique",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/200px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 2
+			}
 		},
 		{
 			"id": "3df7f914-6bce-4f3c-a6c3-581e9c4eebce",
@@ -1311,7 +1375,14 @@
 			"tip": "1 Nightmare unique",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/200px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 3
+			}
 		},
 		{
 			"id": "7af50f50-1d4a-4567-b205-2f35c30eb1b5",
@@ -1319,7 +1390,14 @@
 			"tip": "1 Nightmare unique",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/200px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 4
+			}
 		},
 		{
 			"id": "ac401402-3e8d-4785-86de-1708ce73da65",
@@ -1327,7 +1405,14 @@
 			"tip": "1 Nightmare unique",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/200px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 5
+			}
 		},
 		{
 			"id": "3288456d-a278-414f-9280-3e0dea65cdda",

--- a/tiers/master.json
+++ b/tiers/master.json
@@ -1415,7 +1415,15 @@
 			"tip": "May the bird gods bless you with evil chicken pieces",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log#Miscellaneous",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragon_full_helm_detail.png/277px-Dragon_full_helm_detail.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 1
+			}
 		},
 		{
 			"id": "b8f55499-8c32-4b15-9a70-c80cefb297c1",
@@ -1423,7 +1431,15 @@
 			"tip": "May the bird gods bless you with evil chicken pieces",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log#Miscellaneous",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragon_full_helm_detail.png/277px-Dragon_full_helm_detail.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 2
+			}
 		},
 		{
 			"id": "a1b4d9cc-8e86-45fe-af4b-61d844a5b078",
@@ -1431,7 +1447,15 @@
 			"tip": "May the bird gods bless you with evil chicken pieces",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log#Miscellaneous",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragon_full_helm_detail.png/277px-Dragon_full_helm_detail.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 3
+			}
 		},
 		{
 			"id": "89d777ac-5d60-4720-ba28-e23594ee06c1",
@@ -1439,7 +1463,15 @@
 			"tip": "May the bird gods bless you with evil chicken pieces",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log#Miscellaneous",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragon_full_helm_detail.png/277px-Dragon_full_helm_detail.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 4
+			}
 		},
 		{
 			"id": "1a25f42e-1202-40f3-b001-d2de28f6b530",
@@ -1447,7 +1479,15 @@
 			"tip": "May the bird gods bless you with evil chicken pieces",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Collection_log#Miscellaneous",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragon_full_helm_detail.png/277px-Dragon_full_helm_detail.png",
-			"displayItemId": 11335
+			"displayItemId": 11335,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					21509, 19707, 11335, 22103, 22100, 20439, 20436, 20442, 20433, 24034, 24037,
+					24040, 24043, 24046
+				],
+				"count": 5
+			}
 		},
 		{
 			"id": "bd9208a5-8c14-4fc9-b13f-b5323d036391",
@@ -1481,7 +1521,12 @@
 			"tip": "Boss or Minigame?",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Zalcano",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Zalcano_shard_detail.png/221px-Zalcano_shard_detail.png",
-			"displayItemId": 23908
+			"displayItemId": 23908,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [ 23953, 23908 ],
+				"count": 1
+			}
 		},
 		{
 			"id": "08a9dd78-a0d5-4497-9277-4b66097dba4b",
@@ -1489,7 +1534,12 @@
 			"tip": "Money Dragon",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Vorkath",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragonbone_necklace_detail.png/147px-Dragonbone_necklace_detail.png",
-			"displayItemId": 22111
+			"displayItemId": 22111,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [ 22111, 11286, 22006 ],
+				"count": 1
+			}
 		},
 		{
 			"id": "b759ce53-4312-4a54-8b5d-48a7ec52bd34",
@@ -1497,7 +1547,14 @@
 			"tip": "Ironman retirement home",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/234px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 1
+			}
 		},
 		{
 			"id": "37a77af7-505f-440b-bb3f-5fe03bd1c1a9",
@@ -1505,7 +1562,14 @@
 			"tip": "Ironman retirement home",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/234px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 2
+			}
 		},
 		{
 			"id": "d7f94c27-684f-4f4b-8069-fa8263999a44",
@@ -1513,7 +1577,14 @@
 			"tip": "Ironman retirement home",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/234px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 3
+			}
 		},
 		{
 			"id": "8fa63977-c114-4733-ac89-5b4299e086a2",
@@ -1521,7 +1592,14 @@
 			"tip": "Ironman retirement home",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/234px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 4
+			}
 		},
 		{
 			"id": "384deb72-3c32-4646-ac51-30c661ebcab2",
@@ -1529,7 +1607,14 @@
 			"tip": "Ironman retirement home",
 			"wikiLink": "https://oldschool.runescape.wiki/w/The_Nightmare",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Inquisitor%27s_mace_detail.png/234px-Inquisitor%27s_mace_detail.png",
-			"displayItemId": 24417
+			"displayItemId": 24417,
+			"verification": {
+				"method": "collection-log",
+				"itemIds": [
+					24422, 24517, 24511, 24514, 24419, 24420, 24421, 24417, 25837, 25838
+				],
+				"count": 5
+			}
 		},
 		{
 			"id": "ae31a0d7-1dfa-496a-bcd1-aa0703172b65",

--- a/tiers/medium.json
+++ b/tiers/medium.json
@@ -1128,8 +1128,8 @@
 			"displayItemId": 12954,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 12954 ],
-				"count": 1
+				"itemIds": [ 8844, 8845, 8846, 8847, 8848, 8849, 8850, 12954 ],
+				"count": 8
 			}
 		},
 		{


### PR DESCRIPTION
Changed the defender tasks to include the lower tiers in their item IDs, just for completion sake.
Added Nightmare uniques:
<img width="929" height="182" alt="image" src="https://github.com/user-attachments/assets/2583748e-07c0-4bfd-8f57-66058e6bcdff" />
Added Misc uniques:
<img width="975" height="290" alt="image" src="https://github.com/user-attachments/assets/33e3c42c-0933-4201-b5e7-e0c38d3cb6ef" />
Added Zalcano uniques:
<img width="883" height="58" alt="image" src="https://github.com/user-attachments/assets/0e6809d0-ac90-4569-b7e9-62165ed208e7" />

