### PR TITLE
Fixup some tasks

### DIFF
--- a/lists/official.json
+++ b/lists/official.json
@@ -12918,7 +12918,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 1
 			}
 		},
@@ -12931,7 +12933,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 2
 			}
 		},
@@ -12944,7 +12948,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 3
 			}
 		},
@@ -12957,7 +12963,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 4
 			}
 		},
@@ -12970,7 +12978,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 5
 			}
 		},
@@ -12983,7 +12993,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 6
 			}
 		},
@@ -13108,14 +13120,14 @@
 		},
 		{
 			"id": "08a9dd78-a0d5-4497-9277-4b66097dba4b",
-			"name": "Obtain a Dragonbone necklace",
+			"name": "Get 1 Vorkath unique",
 			"tip": "A rare drop from Vorkath",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Vorkath",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragonbone_necklace_detail.png/147px-Dragonbone_necklace_detail.png",
 			"displayItemId": 22111,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 22111 ],
+				"itemIds": [ 22111, 22006 ],
 				"count": 1
 			}
 		},

--- a/lists/official.json
+++ b/lists/official.json
@@ -8107,10 +8107,10 @@
 			"tip": "Giant, insect-like, demonic boss found in the Tonali Cavern after completion of The Final Dawn quest.",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Doom_of_Mokhaiotl",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Eye_of_ayak_detail.png/320px-Eye_of_ayak_detail.png",
-			"displayItemId": 31113,
+			"displayItemId": 31115,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 31111, 31099, 31109, 31113, 31088 ],
+				"itemIds": [ 31111, 31099, 31109, 31115, 31088 ],
 				"count": 1
 			}
 		},
@@ -8120,10 +8120,10 @@
 			"tip": "Giant, insect-like, demonic boss found in the Tonali Cavern after completion of The Final Dawn quest.",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Doom_of_Mokhaiotl",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Eye_of_ayak_detail.png/320px-Eye_of_ayak_detail.png",
-			"displayItemId": 31113,
+			"displayItemId": 31115,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 31111, 31099, 31109, 31113, 31088 ],
+				"itemIds": [ 31111, 31099, 31109, 31115, 31088 ],
 				"count": 2
 			}
 		}
@@ -11464,10 +11464,10 @@
 			"tip": "Giant, insect-like, demonic boss found in the Tonali Cavern after completion of The Final Dawn quest.",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Doom_of_Mokhaiotl",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Eye_of_ayak_detail.png/320px-Eye_of_ayak_detail.png",
-			"displayItemId": 31113,
+			"displayItemId": 31115,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 31111, 31099, 31109, 31113, 31088 ],
+				"itemIds": [ 31111, 31099, 31109, 31115, 31088 ],
 				"count": 3
 			}
 		},
@@ -11477,10 +11477,10 @@
 			"tip": "Giant, insect-like, demonic boss found in the Tonali Cavern after completion of The Final Dawn quest.",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Doom_of_Mokhaiotl",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Eye_of_ayak_detail.png/320px-Eye_of_ayak_detail.png",
-			"displayItemId": 31113,
+			"displayItemId": 31115,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 31111, 31099, 31109, 31113, 31088 ],
+				"itemIds": [ 31111, 31099, 31109, 31115, 31088 ],
 				"count": 4
 			}
 		}
@@ -14530,10 +14530,10 @@
 			"tip": "Giant, insect-like, demonic boss found in the Tonali Cavern after completion of The Final Dawn quest.",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Doom_of_Mokhaiotl",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Eye_of_ayak_detail.png/320px-Eye_of_ayak_detail.png",
-			"displayItemId": 31113,
+			"displayItemId": 31115,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 31111, 31099, 31109, 31113, 31088 ],
+				"itemIds": [ 31111, 31099, 31109, 31115, 31088 ],
 				"count": 5
 			}
 		}

--- a/lists/tedious.json
+++ b/lists/tedious.json
@@ -8107,10 +8107,10 @@
 			"tip": "Giant, insect-like, demonic boss found in the Tonali Cavern after completion of The Final Dawn quest.",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Doom_of_Mokhaiotl",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Eye_of_ayak_detail.png/320px-Eye_of_ayak_detail.png",
-			"displayItemId": 31113,
+			"displayItemId": 31115,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 31111, 31099, 31109, 31113, 31088 ],
+				"itemIds": [ 31111, 31099, 31109, 31115, 31088 ],
 				"count": 1
 			}
 		},
@@ -8120,10 +8120,10 @@
 			"tip": "Giant, insect-like, demonic boss found in the Tonali Cavern after completion of The Final Dawn quest.",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Doom_of_Mokhaiotl",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Eye_of_ayak_detail.png/320px-Eye_of_ayak_detail.png",
-			"displayItemId": 31113,
+			"displayItemId": 31115,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 31111, 31099, 31109, 31113, 31088 ],
+				"itemIds": [ 31111, 31099, 31109, 31115, 31088 ],
 				"count": 2
 			}
 		}
@@ -11464,10 +11464,10 @@
 			"tip": "Giant, insect-like, demonic boss found in the Tonali Cavern after completion of The Final Dawn quest.",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Doom_of_Mokhaiotl",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Eye_of_ayak_detail.png/320px-Eye_of_ayak_detail.png",
-			"displayItemId": 31113,
+			"displayItemId": 31115,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 31111, 31099, 31109, 31113, 31088 ],
+				"itemIds": [ 31111, 31099, 31109, 31115, 31088 ],
 				"count": 3
 			}
 		},
@@ -11477,10 +11477,10 @@
 			"tip": "Giant, insect-like, demonic boss found in the Tonali Cavern after completion of The Final Dawn quest.",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Doom_of_Mokhaiotl",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Eye_of_ayak_detail.png/320px-Eye_of_ayak_detail.png",
-			"displayItemId": 31113,
+			"displayItemId": 31115,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 31111, 31099, 31109, 31113, 31088 ],
+				"itemIds": [ 31111, 31099, 31109, 31115, 31088 ],
 				"count": 4
 			}
 		}
@@ -13896,10 +13896,10 @@
 			"tip": "Giant, insect-like, demonic boss found in the Tonali Cavern after completion of The Final Dawn quest.",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Doom_of_Mokhaiotl",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Eye_of_ayak_detail.png/320px-Eye_of_ayak_detail.png",
-			"displayItemId": 31113,
+			"displayItemId": 31115,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 31111, 31099, 31109, 31113, 31088 ],
+				"itemIds": [ 31111, 31099, 31109, 31115, 31088 ],
 				"count": 5
 			}
 		}

--- a/lists/tedious.json
+++ b/lists/tedious.json
@@ -12715,7 +12715,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 1
 			}
 		},
@@ -12728,7 +12730,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 2
 			}
 		},
@@ -12741,7 +12745,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 3
 			}
 		},
@@ -12754,7 +12760,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 4
 			}
 		},
@@ -12767,7 +12775,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 5
 			}
 		},
@@ -12892,14 +12902,14 @@
 		},
 		{
 			"id": "dfcb3155-0e12-444e-bab7-c8e3c5aa52cf",
-			"name": "Obtain a Dragonbone necklace",
+			"name": "1 Vorkath unique",
 			"tip": "A rare drop from Vorkath",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Vorkath",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragonbone_necklace_detail.png/200px-Dragonbone_necklace_detail.png",
 			"displayItemId": 22111,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 22111 ],
+				"itemIds": [ 22111, 22006 ],
 				"count": 1
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"gen:lists:tedious": "tsx bin/gen-list.mts tedious easy,medium,hard,elite,master-tedious",
 		"gen:lists": "npm run gen:lists:official && npm run gen:lists:tedious",
 		"gen": "npm run gen:types && npm run gen:uuids && npm run gen:lists",
-		"all": "npm run format && npm run list:schema && npm run gen"
+		"all": "npm run format && npm run lint && npm run gen"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.0.6",

--- a/tiers/elite.json
+++ b/tiers/elite.json
@@ -3336,10 +3336,10 @@
 			"tip": "Giant, insect-like, demonic boss found in the Tonali Cavern after completion of The Final Dawn quest.",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Doom_of_Mokhaiotl",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Eye_of_ayak_detail.png/320px-Eye_of_ayak_detail.png",
-			"displayItemId": 31113,
+			"displayItemId": 31115,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 31111, 31099, 31109, 31113, 31088 ],
+				"itemIds": [ 31111, 31099, 31109, 31115, 31088 ],
 				"count": 3
 			}
 		},
@@ -3349,10 +3349,10 @@
 			"tip": "Giant, insect-like, demonic boss found in the Tonali Cavern after completion of The Final Dawn quest.",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Doom_of_Mokhaiotl",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Eye_of_ayak_detail.png/320px-Eye_of_ayak_detail.png",
-			"displayItemId": 31113,
+			"displayItemId": 31115,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 31111, 31099, 31109, 31113, 31088 ],
+				"itemIds": [ 31111, 31099, 31109, 31115, 31088 ],
 				"count": 4
 			}
 		}

--- a/tiers/hard.json
+++ b/tiers/hard.json
@@ -3149,10 +3149,10 @@
 			"tip": "Giant, insect-like, demonic boss found in the Tonali Cavern after completion of The Final Dawn quest.",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Doom_of_Mokhaiotl",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Eye_of_ayak_detail.png/320px-Eye_of_ayak_detail.png",
-			"displayItemId": 31113,
+			"displayItemId": 31115,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 31111, 31099, 31109, 31113, 31088 ],
+				"itemIds": [ 31111, 31099, 31109, 31115, 31088 ],
 				"count": 1
 			}
 		},
@@ -3162,10 +3162,10 @@
 			"tip": "Giant, insect-like, demonic boss found in the Tonali Cavern after completion of The Final Dawn quest.",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Doom_of_Mokhaiotl",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Eye_of_ayak_detail.png/320px-Eye_of_ayak_detail.png",
-			"displayItemId": 31113,
+			"displayItemId": 31115,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 31111, 31099, 31109, 31113, 31088 ],
+				"itemIds": [ 31111, 31099, 31109, 31115, 31088 ],
 				"count": 2
 			}
 		}

--- a/tiers/master-tedious.json
+++ b/tiers/master-tedious.json
@@ -2411,10 +2411,10 @@
 			"tip": "Giant, insect-like, demonic boss found in the Tonali Cavern after completion of The Final Dawn quest.",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Doom_of_Mokhaiotl",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Eye_of_ayak_detail.png/320px-Eye_of_ayak_detail.png",
-			"displayItemId": 31113,
+			"displayItemId": 31115,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 31111, 31099, 31109, 31113, 31088 ],
+				"itemIds": [ 31111, 31099, 31109, 31115, 31088 ],
 				"count": 5
 			}
 		}

--- a/tiers/master-tedious.json
+++ b/tiers/master-tedious.json
@@ -1230,7 +1230,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 1
 			}
 		},
@@ -1243,7 +1245,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 2
 			}
 		},
@@ -1256,7 +1260,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 3
 			}
 		},
@@ -1269,7 +1275,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 4
 			}
 		},
@@ -1282,7 +1290,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 5
 			}
 		},
@@ -1407,14 +1417,14 @@
 		},
 		{
 			"id": "dfcb3155-0e12-444e-bab7-c8e3c5aa52cf",
-			"name": "Obtain a Dragonbone necklace",
+			"name": "1 Vorkath unique",
 			"tip": "A rare drop from Vorkath",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Vorkath",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragonbone_necklace_detail.png/200px-Dragonbone_necklace_detail.png",
 			"displayItemId": 22111,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 22111 ],
+				"itemIds": [ 22111, 22006 ],
 				"count": 1
 			}
 		},

--- a/tiers/master.json
+++ b/tiers/master.json
@@ -3045,10 +3045,10 @@
 			"tip": "Giant, insect-like, demonic boss found in the Tonali Cavern after completion of The Final Dawn quest.",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Doom_of_Mokhaiotl",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Eye_of_ayak_detail.png/320px-Eye_of_ayak_detail.png",
-			"displayItemId": 31113,
+			"displayItemId": 31115,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 31111, 31099, 31109, 31113, 31088 ],
+				"itemIds": [ 31111, 31099, 31109, 31115, 31088 ],
 				"count": 5
 			}
 		}

--- a/tiers/master.json
+++ b/tiers/master.json
@@ -1433,7 +1433,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 1
 			}
 		},
@@ -1446,7 +1448,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 2
 			}
 		},
@@ -1459,7 +1463,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 3
 			}
 		},
@@ -1472,7 +1478,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 4
 			}
 		},
@@ -1485,7 +1493,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 5
 			}
 		},
@@ -1498,7 +1508,9 @@
 			"displayItemId": 20724,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963 ],
+				"itemIds": [
+					20724, 21270, 23047, 23050, 23053, 23056, 23059, 22963, 11286, 21637
+				],
 				"count": 6
 			}
 		},
@@ -1623,14 +1635,14 @@
 		},
 		{
 			"id": "08a9dd78-a0d5-4497-9277-4b66097dba4b",
-			"name": "Obtain a Dragonbone necklace",
+			"name": "Get 1 Vorkath unique",
 			"tip": "A rare drop from Vorkath",
 			"wikiLink": "https://oldschool.runescape.wiki/w/Vorkath",
 			"imageLink": "https://oldschool.runescape.wiki/images/thumb/Dragonbone_necklace_detail.png/147px-Dragonbone_necklace_detail.png",
 			"displayItemId": 22111,
 			"verification": {
 				"method": "collection-log",
-				"itemIds": [ 22111 ],
+				"itemIds": [ 22111, 22006 ],
 				"count": 1
 			}
 		},


### PR DESCRIPTION
Fixed Eye of ayak ID

Added Skeletal Visage to Vorkath, as this is a Vorkath unique

Added Wyvern Visage and Draconic Visage to the `Get 1 slayer log slot` tasks as these appear under the slayer log in game, and are not under any other tasks
<img width="311" height="121" alt="image" src="https://github.com/user-attachments/assets/208e49f2-d2fe-449e-88de-bd98aa68768e" />
